### PR TITLE
fix(notifications): mark all notifications done when subject is closed

### DIFF
--- a/apps/notifications/src/policy.ts
+++ b/apps/notifications/src/policy.ts
@@ -50,7 +50,31 @@ const PROTECTED_REASONS = new Set([
   "state_change",
   "team_mention",
 ]);
+const CLOSEABLE_SUBJECT_TYPES = new Set(["PullRequest", "Issue"]);
+const SUBJECT_TYPE_LABEL: Record<string, string> = {
+  PullRequest: "pull request",
+  Issue: "issue",
+};
 const STALE_APPROVAL_REQUEST_MS = 24 * 60 * 60 * 1000;
+
+function keep(reason: string): NotificationDecision {
+  return { action: "keep", reason };
+}
+
+function markDone(reason: string): NotificationDecision {
+  return { action: "mark-done", reason };
+}
+
+function extractIdentity(subject: GitHubSubject | undefined): string | undefined {
+  const author =
+    subject?.user?.login ??
+    subject?.author?.login ??
+    subject?.actor?.login ??
+    subject?.triggering_actor?.login;
+  const app = subject?.app?.slug ?? subject?.app?.name;
+  const raw = author?.endsWith("[bot]") ? author.slice(0, -5) : (author ?? app);
+  return raw || undefined;
+}
 
 export function shouldFetchSubject(notification: GitHubNotification) {
   return Boolean(
@@ -100,10 +124,7 @@ async function classifyApprovalRequest(
 
   if (stale) {
     return {
-      decision: {
-        action: "mark-done",
-        reason: "approval request is stale",
-      },
+      decision: markDone("approval request is stale"),
     };
   }
 
@@ -114,14 +135,8 @@ async function classifyApprovalRequest(
   return {
     decision:
       pendingDeployments.length === 0
-        ? {
-            action: "mark-done",
-            reason: "approval request has no pending deployments",
-          }
-        : {
-            action: "keep",
-            reason: "approval request still has pending deployments",
-          },
+        ? markDone("approval request has no pending deployments")
+        : keep("approval request still has pending deployments"),
     pendingDeployments,
   };
 }
@@ -142,97 +157,67 @@ export function classify(
   notification: GitHubNotification,
   subject?: GitHubSubject,
 ): NotificationDecision {
-  const author =
-    subject?.user?.login ??
-    subject?.author?.login ??
-    subject?.actor?.login ??
-    subject?.triggering_actor?.login;
-  const app = subject?.app?.slug ?? subject?.app?.name;
-  const identity = author?.endsWith("[bot]") ? author.slice(0, -5) : (author ?? app);
-
+  // 1. Workflow failure notifications — no subject needed
   if (
     notification.reason === "ci_activity" &&
     (notification.subject.type === "CheckSuite" || notification.subject.type === "WorkflowRun") &&
     /run failed (at startup )?for .+ branch/i.test(notification.subject.title)
   ) {
-    return {
-      action: "mark-done" as const,
-      reason: "workflow failure ci_activity is auto-done",
-    };
+    return markDone("workflow failure ci_activity is auto-done");
   }
 
+  // 2. Subscribed release notifications — no subject needed
   if (notification.subject.type === "Release" && notification.reason === "subscribed") {
-    return {
-      action: "mark-done" as const,
-      reason: "release subscribed notification is auto-done",
-    };
+    return markDone("release subscribed notification is auto-done");
   }
 
+  // 3. Closed/merged subjects — any notification about a finished PR or Issue is stale.
+  //    Runs before NEVER_AUTO_DONE so a closed subject is always removed from the inbox.
   if (
-    (notification.reason === "author" || notification.reason === "review_requested") &&
-    notification.subject.type === "PullRequest" &&
+    CLOSEABLE_SUBJECT_TYPES.has(notification.subject.type) &&
     (subject?.merged || subject?.state === "closed")
   ) {
-    return {
-      action: "mark-done" as const,
-      reason: `pull request ${notification.reason} notification is closed`,
-    };
+    const label = SUBJECT_TYPE_LABEL[notification.subject.type] ?? notification.subject.type.toLowerCase();
+    return markDone(`${label} ${notification.reason} notification is closed`);
   }
 
+  const identity = extractIdentity(subject);
+
+  // 4. Identities that should never be auto-done
   if (identity && NEVER_AUTO_DONE_IDENTITIES.has(identity)) {
-    return {
-      action: "keep" as const,
-      reason: `subject identity ${identity} is never auto-done`,
-    };
+    return keep(`subject identity ${identity} is never auto-done`);
   }
 
+  // 5. Identities that are always auto-done (bots/apps that generate noise)
   if (identity && ALWAYS_AUTO_DONE_IDENTITIES.has(identity)) {
-    return {
-      action: "mark-done" as const,
-      reason: `subject identity ${identity} is always auto-done`,
-    };
+    return markDone(`subject identity ${identity} is always auto-done`);
   }
 
+  // 6. Subject type not supported or URL missing — cannot inspect further
   if (!notification.subject.url || !SUPPORTED_SUBJECT_TYPES.has(notification.subject.type)) {
-    return {
-      action: "keep" as const,
-      reason: `subject type ${notification.subject.type} is not supported`,
-    };
+    return keep(`subject type ${notification.subject.type} is not supported`);
   }
 
+  // 7. Review requests — check whether the reviewer list is still active
   if (notification.reason === "review_requested" && notification.subject.type === "PullRequest") {
     if (!subject) {
-      return {
-        action: "keep" as const,
-        reason: "pull request review request could not be checked",
-      };
+      return keep("pull request review request could not be checked");
     }
 
     if (
       (subject?.requested_reviewers?.length ?? 0) === 0 &&
       (subject?.requested_teams?.length ?? 0) === 0
     ) {
-      return {
-        action: "mark-done" as const,
-        reason: "pull request review request is no longer pending",
-      };
+      return markDone("pull request review request is no longer pending");
     }
 
-    return {
-      action: "keep" as const,
-      reason: "pull request review request is still pending",
-    };
+    return keep("pull request review request is still pending");
   }
 
+  // 8. Protected reasons represent human-relevant interactions
   if (PROTECTED_REASONS.has(notification.reason)) {
-    return {
-      action: "keep" as const,
-      reason: `notification reason ${notification.reason} is protected`,
-    };
+    return keep(`notification reason ${notification.reason} is protected`);
   }
 
-  return {
-    action: "keep" as const,
-    reason: identity ? `subject identity ${identity} is kept` : "subject has no identity",
-  };
+  return keep(identity ? `subject identity ${identity} is kept` : "subject has no identity");
 }

--- a/apps/notifications/test/fixtures/closed-author-issue-notification.json
+++ b/apps/notifications/test/fixtures/closed-author-issue-notification.json
@@ -1,0 +1,13 @@
+{
+  "id": "closed-author-issue-notification",
+  "reason": "author",
+  "updated_at": "2026-06-11T00:00:00Z",
+  "repository": {
+    "full_name": "luxass/cloudflare-workers"
+  },
+  "subject": {
+    "title": "bug: something broken",
+    "type": "Issue",
+    "url": "https://api.github.com/repos/luxass/cloudflare-workers/issues/42"
+  }
+}

--- a/apps/notifications/test/fixtures/closed-author-issue-subject.json
+++ b/apps/notifications/test/fixtures/closed-author-issue-subject.json
@@ -1,0 +1,7 @@
+{
+  "html_url": "https://github.com/luxass/cloudflare-workers/issues/42",
+  "state": "closed",
+  "user": {
+    "login": "luxass"
+  }
+}

--- a/apps/notifications/test/fixtures/comment-merged-pr-notification.json
+++ b/apps/notifications/test/fixtures/comment-merged-pr-notification.json
@@ -1,0 +1,13 @@
+{
+  "id": "comment-merged-pr-notification",
+  "reason": "comment",
+  "updated_at": "2026-06-13T00:00:00Z",
+  "repository": {
+    "full_name": "luxass/cloudflare-workers"
+  },
+  "subject": {
+    "title": "Add CHANGELOG.md",
+    "type": "PullRequest",
+    "url": "https://api.github.com/repos/luxass/cloudflare-workers/pulls/42"
+  }
+}

--- a/apps/notifications/test/fixtures/comment-merged-pr-subject.json
+++ b/apps/notifications/test/fixtures/comment-merged-pr-subject.json
@@ -1,0 +1,10 @@
+{
+  "html_url": "https://github.com/luxass/cloudflare-workers/pull/42",
+  "state": "closed",
+  "merged": true,
+  "user": {
+    "login": "somedev"
+  },
+  "requested_reviewers": [],
+  "requested_teams": []
+}

--- a/apps/notifications/test/fixtures/state-change-pr-notification.json
+++ b/apps/notifications/test/fixtures/state-change-pr-notification.json
@@ -1,0 +1,13 @@
+{
+  "id": "state-change-pr-notification",
+  "reason": "state_change",
+  "updated_at": "2026-06-11T00:00:00Z",
+  "repository": {
+    "full_name": "luxass/cloudflare-workers"
+  },
+  "subject": {
+    "title": "feat: shipped thing",
+    "type": "PullRequest",
+    "url": "https://api.github.com/repos/luxass/cloudflare-workers/pulls/12"
+  }
+}

--- a/apps/notifications/test/fixtures/state-change-pr-subject.json
+++ b/apps/notifications/test/fixtures/state-change-pr-subject.json
@@ -1,0 +1,10 @@
+{
+  "html_url": "https://github.com/luxass/cloudflare-workers/pull/12",
+  "state": "closed",
+  "merged": true,
+  "user": {
+    "login": "luxass"
+  },
+  "requested_reviewers": [],
+  "requested_teams": []
+}

--- a/apps/notifications/test/policy.test.ts
+++ b/apps/notifications/test/policy.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import approvalNotification from "./fixtures/approval-requested-notification.json";
 import pendingDeployment from "./fixtures/approval-requested-pending-deployment.json";
+import commentMergedPrNotification from "./fixtures/comment-merged-pr-notification.json";
+import commentMergedPrSubject from "./fixtures/comment-merged-pr-subject.json";
+import closedAuthorIssueNotification from "./fixtures/closed-author-issue-notification.json";
+import closedAuthorIssueSubject from "./fixtures/closed-author-issue-subject.json";
 import closedAuthorNotification from "./fixtures/closed-author-pr-notification.json";
 import closedAuthorSubject from "./fixtures/closed-author-pr-subject.json";
 import coderabbitNotification from "./fixtures/coderabbit-pr-notification.json";
@@ -17,6 +21,8 @@ import renovateSubject from "./fixtures/renovate-pr-subject.json";
 import releaseNotification from "./fixtures/release-notification.json";
 import staleReviewNotification from "./fixtures/stale-review-pr-notification.json";
 import staleReviewSubject from "./fixtures/stale-review-pr-subject.json";
+import stateChangePrNotification from "./fixtures/state-change-pr-notification.json";
+import stateChangePrSubject from "./fixtures/state-change-pr-subject.json";
 import teamReviewNotification from "./fixtures/team-review-pr-notification.json";
 import teamReviewSubject from "./fixtures/team-review-pr-subject.json";
 import unsupportedWorkflowNotification from "./fixtures/unsupported-workflow-notification.json";
@@ -285,6 +291,63 @@ describe("notification policy", () => {
     expect(result.decision).toEqual({
       action: "mark-done",
       reason: "release subscribed notification is auto-done",
+    });
+  });
+
+  it("marks a comment notification done after the pull request merges", async () => {
+    const notification = commentMergedPrNotification as GitHubNotification;
+    const subject = commentMergedPrSubject as GitHubSubject;
+    const subjectReads: GitHubNotification[] = [];
+
+    const result = await classifyNotification(notification, async (notification) => {
+      subjectReads.push(notification);
+      return subject;
+    });
+
+    expect(subjectReads).toEqual([notification]);
+    expect(result.subject).toBe(subject);
+    expect(result.subjectAuthor).toBe("somedev");
+    expect(result.decision).toEqual({
+      action: "mark-done",
+      reason: "pull request comment notification is closed",
+    });
+  });
+
+  it("marks a state_change notification done after the pull request closes", async () => {
+    const notification = stateChangePrNotification as GitHubNotification;
+    const subject = stateChangePrSubject as GitHubSubject;
+    const subjectReads: GitHubNotification[] = [];
+
+    const result = await classifyNotification(notification, async (notification) => {
+      subjectReads.push(notification);
+      return subject;
+    });
+
+    expect(subjectReads).toEqual([notification]);
+    expect(result.subject).toBe(subject);
+    expect(result.subjectAuthor).toBe("luxass");
+    expect(result.decision).toEqual({
+      action: "mark-done",
+      reason: "pull request state_change notification is closed",
+    });
+  });
+
+  it("marks an author notification done after the issue closes", async () => {
+    const notification = closedAuthorIssueNotification as GitHubNotification;
+    const subject = closedAuthorIssueSubject as GitHubSubject;
+    const subjectReads: GitHubNotification[] = [];
+
+    const result = await classifyNotification(notification, async (notification) => {
+      subjectReads.push(notification);
+      return subject;
+    });
+
+    expect(subjectReads).toEqual([notification]);
+    expect(result.subject).toBe(subject);
+    expect(result.subjectAuthor).toBe("luxass");
+    expect(result.decision).toEqual({
+      action: "mark-done",
+      reason: "issue author notification is closed",
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -31,5 +31,5 @@
     "vitest": "catalog:dev",
     "wrangler": "catalog:dev"
   },
-  "packageManager": "pnpm@11.1.0"
+  "packageManager": "pnpm@11.5.2"
 }


### PR DESCRIPTION
## Summary

- Any notification about a merged or closed PR/Issue is stale — there is no inbox action left to take. The previous policy only auto-done a narrow set of reasons (`author`, `review_requested`, `state_change`), leaving `comment`, `mention`, `assign`, and others accumulating indefinitely after the subject closed.
- Drops the per-reason filter from the closed-subject rule so it fires for every notification reason on a closed/merged PR or Issue.
- Extends the rule from `PullRequest`-only to also cover `Issues`.
- Refactors `classify()` with `markDone()`/`keep()` helpers and numbered section comments to make rule precedence explicit.

## Test plan

- [x] All 17 tests pass (`pnpm --filter notifications test`)
- [x] New test: `comment` notification on a merged PR → `mark-done`
- [x] New test: `state_change` notification on a closed PR → `mark-done`
- [x] New test: `author` notification on a closed Issue → `mark-done`
- [x] Existing tests unchanged — `NEVER_AUTO_DONE` identities, approval requests, review pending checks, protected reasons on open subjects all behave as before