### PR TITLE
feat(notifications): handle inaccessible subjects on private repos

### DIFF
--- a/apps/notifications/src/github.ts
+++ b/apps/notifications/src/github.ts
@@ -10,6 +10,7 @@ export interface GitHubNotification {
   updated_at: string;
   repository: {
     full_name: string;
+    private: boolean;
   };
   subject: {
     title: string;
@@ -83,7 +84,7 @@ const DEFAULT_MAX_PAGES = 5;
 const GITHUB_FETCH_TIMEOUT_MS = 15_000;
 const PER_PAGE = 50;
 
-class GitHubRequestError extends Error {
+export class GitHubRequestError extends Error {
   constructor(
     readonly request: {
       method: string;

--- a/apps/notifications/src/index.ts
+++ b/apps/notifications/src/index.ts
@@ -5,6 +5,7 @@ import {
   type GitHubPendingDeploymentWithRun,
   type GitHubSubject,
   type PollState,
+  GitHubRequestError,
   listNotificationThreads,
   listPendingDeploymentsForWaitingRuns,
   markNotificationThreadDone,
@@ -129,7 +130,20 @@ export default {
               // request per URL for the whole poll.
               let request = subjects.get(url);
               if (!request) {
-                request = readNotificationSubject(env, notification);
+                request = readNotificationSubject(env, notification).catch((err) => {
+                  if (err instanceof GitHubRequestError && (err.request.status === 404 || err.request.status === 403)) {
+                    eventLog.warn({
+                      operation: "github_notification_subject_fetch",
+                      message: "GitHub notification subject not accessible",
+                      status: err.request.status,
+                      private: notification.repository.private,
+                      url,
+                      repository: notification.repository.full_name,
+                    });
+                    return undefined;
+                  }
+                  throw err;
+                });
                 subjects.set(url, request);
               }
 


### PR DESCRIPTION
## Summary

- When a subject fetch returns 403 or 404 (private org repo the token can't access, deleted PR/Issue), the notification is now kept gracefully instead of counted as a failure
- Adds `repository.private: boolean` to `GitHubNotification` so the warning log includes whether the inaccessible subject was on a private repo — makes it easy to distinguish "no token access" from "resource genuinely missing"
- Exports `GitHubRequestError` so `index.ts` can catch and inspect it specifically

## Test plan

- [x] `pnpm --filter notifications typecheck` passes
- [x] `pnpm --filter notifications test` — all 17 tests pass