### PR TITLE
fix(notifications): restore since param and use all=true for read notifications

### DIFF
--- a/apps/notifications/src/github.ts
+++ b/apps/notifications/src/github.ts
@@ -1,5 +1,6 @@
 export interface PollState {
   lastModified?: string;
+  lastPolledAt?: string;
   nextPollAt?: number;
 }
 
@@ -207,6 +208,9 @@ export async function listNotificationThreads(env: CloudflareBindings, state: Po
     url.searchParams.set("participating", "false");
     url.searchParams.set("per_page", String(PER_PAGE));
     url.searchParams.set("page", String(page));
+    if (page === 1 && state.lastPolledAt) {
+      url.searchParams.set("since", state.lastPolledAt);
+    }
 
     response = await githubNotificationsFetch({
       env,

--- a/apps/notifications/src/index.ts
+++ b/apps/notifications/src/index.ts
@@ -48,6 +48,7 @@ export default {
           // When the page limit is hit, keep the old validator so the next poll
           // continues from a full notifications response instead of accepting 304.
           lastModified: result.hitPageLimit ? state.lastModified : nextState.lastModified,
+          lastPolledAt: new Date(startedAt).toISOString(),
         }),
       );
 


### PR DESCRIPTION
## Summary

- Adds `lastPolledAt` to `PollState` — stored as ISO 8601 string after each successful poll
- Passes it as `since=` on page 1 of the notifications request so only notifications with activity since the last poll are returned
- Keeps `all=true` so manually-read notifications (unread=false) are still visible to the policy

## Why

Without `since`, `all=true` returns every notification in the inbox on every poll — including stale kept notifications — causing unnecessary re-processing. With `since`, only notifications that have seen new activity since the last poll are returned, which is exactly what's needed.

`If-Modified-Since` / 304 still works as before for the free skip when nothing changed at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized GitHub notifications polling with timestamp-based filtering to reduce redundant fetches and improve polling efficiency on subsequent requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->